### PR TITLE
Add OAuth2 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # SSO Backend
 
-Este proyecto es una API sencilla de autenticación implementada con **Django** y **Django REST Framework**. Proporciona un mecanismo de inicio de sesión, registro de usuarios y obtención de tokens JWT empleando `rest_framework_simplejwt`. También incluye soporte CORS para permitir peticiones desde un cliente front‑end.
-
+Este proyecto es una API sencilla de autenticación implementada con **Django** y **Django REST Framework**. Proporciona un mecanismo de inicio de sesión, registro de usuarios y obtención de tokens JWT empleando `rest_framework_simplejwt`. También incluye soporte CORS para permitir peticiones desde un cliente front‑end. Ahora incorpora un proveedor **OAuth2** mediante `django-oauth-toolkit` para facilitar la identidad federada.
 ## Requisitos
 
 - Python 3.10 o superior
@@ -34,7 +33,7 @@ Este proyecto es una API sencilla de autenticación implementada con **Django** 
    `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST` y
    `POSTGRES_PORT` en el archivo `.env`.
 
-4. Aplicar migraciones y ejecutar el servidor de desarrollo:
+4. Aplicar migraciones (incluyen las tablas de `django-oauth-toolkit`) y ejecutar el servidor de desarrollo:
 
    ```bash
    python manage.py migrate
@@ -48,6 +47,8 @@ Este proyecto es una API sencilla de autenticación implementada con **Django** 
 - `POST /sso/logout/` — cierra la sesión eliminando la cookie de refresco.
 - `GET /sso/me/` — devuelve información del usuario autenticado.
 - `POST /sso/register/` — crea un nuevo usuario.
+
+Para flujos OAuth2 estándar puedes utilizar los endpoints incluidos bajo la ruta `/o/` que proporciona `django-oauth-toolkit` (por ejemplo `POST /o/token/` para obtener un token de acceso).
 
 Todos los endpoints anteriores se definen en el módulo `sso`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ django-cors-headers
 djangorestframework-simplejwt
 python-decouple
 psycopg2-binary
+django-oauth-toolkit==3.0.1

--- a/sso_backend/settings.py
+++ b/sso_backend/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'oauth2_provider',
     'corsheaders',
     'sso',
 ]
@@ -145,7 +146,15 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
     ),
+}
+
+OAUTH2_PROVIDER = {
+    'SCOPES': {
+        'read': 'Lectura de datos',
+        'write': 'Escritura de datos',
+    }
 }
 
 CORS_ALLOWED_ORIGINS = [

--- a/sso_backend/urls.py
+++ b/sso_backend/urls.py
@@ -3,5 +3,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('api/', include('sso.urls')),
 ]


### PR DESCRIPTION
## Summary
- add django-oauth-toolkit dependency
- configure oauth2_provider in settings and urls
- document OAuth2 endpoints in README

## Testing
- `pip install -r requirements.txt`
- `python manage.py migrate --noinput`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6854238f16508328a05f8b8093a3f6c5